### PR TITLE
fix: ast parser error

### DIFF
--- a/extensions/material-helper/CHANGELOG.md
+++ b/extensions/material-helper/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## 1.0.9
+
+- fix: the code in the editor is incomplete will cause the AST parser error.
+
 ## 1.0.8
 
 - fix: update code snippets, the snippet - mtop.[request | config] => mtop[Request | Config]

--- a/extensions/material-helper/package.json
+++ b/extensions/material-helper/package.json
@@ -3,7 +3,7 @@
   "displayName": "Component Helper",
   "description": "Easily use Component in React/Vue/Rax.",
   "publisher": "iceworks-team",
-  "version": "1.0.8",
+  "version": "1.0.9",
   "main": "./build/extension.js",
   "engines": {
     "vscode": "^1.41.0"

--- a/extensions/material-helper/src/importAutoComplete/getAlreadyImportSet.ts
+++ b/extensions/material-helper/src/importAutoComplete/getAlreadyImportSet.ts
@@ -12,6 +12,7 @@ export default (doc: vscode.TextDocument): Set<string> => {
     const ast = parse(documentText, {
       sourceType: 'module',
       plugins: getBabelParserPlugins('jsx'),
+      errorRecovery: true,
     });
     traverse(ast, {
       ImportDeclaration(path: NodePath<ImportDeclaration>) {

--- a/extensions/material-helper/src/propTypesAutoComplete/getPropTypesDependentName.ts
+++ b/extensions/material-helper/src/propTypesAutoComplete/getPropTypesDependentName.ts
@@ -10,6 +10,7 @@ export default (code: string, uri: vscode.Uri): string => {
     const ast = parse(code, {
       sourceType: 'module',
       plugins: getBabelParserPlugins('jsx'),
+      errorRecovery: true,
     });
 
     const propTypesDependentName = getImportDependentName(ast, 'prop-types');


### PR DESCRIPTION
the code in the editor is incomplete will cause the AST parser error.
When `@babel/parser errorRecovery` this option is set to true, it will store the parsing error and try to continue parsing the invalid input file.