### PR TITLE
chore: remove @ali/publish-visual extension

### DIFF
--- a/scripts/o2/config.ts
+++ b/scripts/o2/config.ts
@@ -32,7 +32,14 @@ export const innerExtensions4pack = [
   },
 ];
 
-const otherExtensions: OtherExtension[] = [];
+const otherExtensions: OtherExtension[] = [
+  // {
+  //   packageName: '@ali/publish-visual',
+  //   assetsFolders: ['icons', 'resource'],
+  //   isActiveNode: true,
+  //   isActiveBrowser: true,
+  // },
+];
 
 export const otherExtensions4pack = otherExtensions.map((otherExtension4pack) => (
   { ...otherExtension4pack, extensionName: camelCase(otherExtension4pack.packageName), isOther: true }

--- a/scripts/o2/config.ts
+++ b/scripts/o2/config.ts
@@ -33,6 +33,7 @@ export const innerExtensions4pack = [
 ];
 
 const otherExtensions: OtherExtension[] = [
+  // install this extension in DEF extension marketplace
   // {
   //   packageName: '@ali/publish-visual',
   //   assetsFolders: ['icons', 'resource'],

--- a/scripts/o2/config.ts
+++ b/scripts/o2/config.ts
@@ -1,5 +1,12 @@
 import * as camelCase from 'lodash.camelcase';
 
+interface OtherExtension {
+  packageName: string;
+  assetsFolders: string[];
+  isActiveNode: boolean;
+  isActiveBrowser: boolean;
+}
+
 export const isBeta = !process.env.CI; // CI is true when running in GitHub action
 export const pushExtension2Npm = false; // modify it to true when publish to tnpm
 export const innerExtensions4pack = [
@@ -24,13 +31,11 @@ export const innerExtensions4pack = [
     assetsFolders: ['assets', 'schemas'],
   },
 ];
-export const otherExtensions4pack = [
-  {
 
-    packageName: '@ali/publish-visual',
-    assetsFolders: ['icons', 'resource'],
-    isActiveNode: true,
-    isActiveBrowser: true,
-  },
-].map((otherExtension4pack) => ({ ...otherExtension4pack, extensionName: camelCase(otherExtension4pack.packageName), isOther: true }));
+const otherExtensions: OtherExtension[] = [];
+
+export const otherExtensions4pack = otherExtensions.map((otherExtension4pack) => (
+  { ...otherExtension4pack, extensionName: camelCase(otherExtension4pack.packageName), isOther: true }
+));
+
 export const npmRegistry = process.env.REGISTRY ? process.env.REGISTRY : 'https://registry.npm.alibaba-inc.com';


### PR DESCRIPTION
移除在 O2 上对 DEF 可视化发布插件的依赖，避免升级维护的成本