### PR TITLE
fix: fail to remove compoennt

### DIFF
--- a/extensions/application-manager/CHANGELOG.md
+++ b/extensions/application-manager/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## 1.0.6
+
+- fix: async function syntax error
+
 ## 1.0.5
 
 - feat: update activitybar icon

--- a/extensions/application-manager/package.json
+++ b/extensions/application-manager/package.json
@@ -3,7 +3,7 @@
   "displayName": "Application Manager",
   "description": "Quick view your Universal Application(React/Rax/Vue, etc).",
   "publisher": "iceworks-team",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "engines": {
     "vscode": "^1.41.0"
   },

--- a/extensions/application-manager/src/views/actionsView.ts
+++ b/extensions/application-manager/src/views/actionsView.ts
@@ -44,7 +44,7 @@ export class ActionsProvider implements vscode.TreeDataProvider<ItemData> {
       itemDataList = element.children;
     } else {
       itemDataList = [
-        ...this.buildQuickItems(),
+        ...await this.buildQuickItems(),
         this.buildDividerItem(),
         await this.buildScriptParentItem(),
       ];
@@ -84,7 +84,7 @@ export class ActionsProvider implements vscode.TreeDataProvider<ItemData> {
     return item;
   }
 
-  private buildQuickItems(): ItemData[] {
+  private async buildQuickItems(): Promise<ItemData[]> {
     const items: ItemData[] = [];
     const debugLabel = i18n.format('extension.applicationManager.showEntriesQuickPick.runDebug.label');
     const debugItem = this.buildActionItem(
@@ -112,7 +112,7 @@ export class ActionsProvider implements vscode.TreeDataProvider<ItemData> {
       items.push(createPageItem);
     }
 
-    const isAliInternal = checkIsAliInternal();
+    const isAliInternal = await checkIsAliInternal();
     if (isAliInternal) {
       const publishLabel = i18n.format('extension.applicationManager.showEntriesQuickPick.DefPublish.label');
       const publishItem = this.buildActionItem(

--- a/extensions/material-helper/CHANGELOG.md
+++ b/extensions/material-helper/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## 1.0.10
+
+- chore: add iceworks-refactor to extensionDependencies
+
 ## 1.0.9
 
 - feat: change auto fill code to React Generator extension. 

--- a/extensions/material-helper/package.json
+++ b/extensions/material-helper/package.json
@@ -3,7 +3,7 @@
   "displayName": "Component Helper",
   "description": "Easily use Component in React/Vue/Rax.",
   "publisher": "iceworks-team",
-  "version": "1.0.9",
+  "version": "1.0.10",
   "main": "./build/extension.js",
   "engines": {
     "vscode": "^1.41.0"
@@ -385,5 +385,8 @@
   "bugs": {
     "url": "https://github.com/appworks-lab/appworks/issues",
     "email": "iceworksteam@163.com"
-  }
+  },
+  "extensionDependencies": [
+    "iceworks-team.iceworks-refactor"
+  ]
 }

--- a/extensions/material-helper/src/views/componentsView.ts
+++ b/extensions/material-helper/src/views/componentsView.ts
@@ -175,9 +175,7 @@ export function createComponentsTreeView(context: vscode.ExtensionContext) {
       i18n.format('extension.iceworksMaterialHelper.cancel'),
     );
     if (choice === confirmTitle) {
-      if (vscode.extensions.getExtension('iceworks-team.iceworks-refactor')) {
-        await vscode.commands.executeCommand('react-refactor.file-and-reference.remove', { path: component.fsPath });
-      }
+      await vscode.commands.executeCommand('react-refactor.file-and-reference.remove', { path: component.fsPath });
     }
   });
 

--- a/scripts/o2/config.ts
+++ b/scripts/o2/config.ts
@@ -23,6 +23,14 @@ export const innerExtensions4pack = [
     packageName: 'iceworks-team.iceworks-time-master',
     assetsFolders: ['assets', 'schemas'],
   },
+  {
+    packageName: 'iceworks-team.iceworks-refactor',
+    assetsFolders: ['assets', 'schemas'],
+  },
+  {
+    packageName: 'iceworks-team.iceworks-generator',
+    assetsFolders: ['assets', 'schemas'],
+  },
 ];
 export const otherExtensions4pack = [
   {


### PR DESCRIPTION
### 背景
在 O2 上无法删除组件

### 原因
假如没有安装 refactor 插件，则无法调用 refactor 提供的命令删除组件

### 解决
material-helper 插件增加依赖 refactor 插件，同时 O2 打包时把 reactor 插件也打包进去
