### PR TITLE
chore: add @ali/publish-visual to o2 pack

### DIFF
--- a/scripts/o2/config.ts
+++ b/scripts/o2/config.ts
@@ -33,13 +33,12 @@ export const innerExtensions4pack = [
 ];
 
 const otherExtensions: OtherExtension[] = [
-  // install this extension in DEF extension marketplace
-  // {
-  //   packageName: '@ali/publish-visual',
-  //   assetsFolders: ['icons', 'resource'],
-  //   isActiveNode: true,
-  //   isActiveBrowser: true,
-  // },
+  {
+    packageName: '@ali/publish-visual',
+    assetsFolders: ['icons', 'resource'],
+    isActiveNode: true,
+    isActiveBrowser: true,
+  },
 ];
 
 export const otherExtensions4pack = otherExtensions.map((otherExtension4pack) => (


### PR DESCRIPTION
和与天和魁武讨论过，从 iceworks-kit 中去掉 @ali/publish-visual，可能现有用户无法使用。讨论结果是保持现在内置插件的状态